### PR TITLE
attempt to rebind USB device after reset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,14 @@ services:
       - type: bind
         source: ./kasm_user
         target: /home/kasm-user
+      - /run/udev:/run/udev:ro
+      - /dev:/dev
 #      - type: bind
 #        source: /run/user/1000/pulse/
 #        target: /run/user/1000/pulse/
+    device_cgroup_rules:
+      - "c 188:* rmw"
+    privileged: true
     security_opt:
       - seccomp=unconfined
 ...


### PR DESCRIPTION
follows approach using cgroup rule as per https://stackoverflow.com/questions/24225647/docker-a-way-to-give-access-to-a-host-usb-or-serial-device

closes #11
closes #9 