### PR TITLE
update CI to use latest gh-actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,33 +38,36 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout github repo
+        uses: actions/checkout@v2
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
-          tag-sha: true
-          tag-edge: false
-          tag-latest: true
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
 
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_AUTH_TOKEN }}
 
       - name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           tags: ${{ steps.docker_meta.outputs.tags }} 
           file: ./Dockerfile
           
       - name: Push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-          file: ./Dockerfile    
+          file: ./Dockerfile


### PR DESCRIPTION
closes #36 

- update to use docker/metadata-action@v4
- set ghcr tags to branch, pr, & git tag
- update to use docker/login-action@v2.1.0
- update to use docker/build-push-action@v4.0.0